### PR TITLE
Revert "BAI Standalone 25.0.0-IF005"

### DIFF
--- a/descriptors/op-olm/catalog_source.yaml
+++ b/descriptors/op-olm/catalog_source.yaml
@@ -33,7 +33,7 @@ spec:
   publisher: IBM
   sourceType: grpc
   image: >-
-    icr.io/cpopen/ibm-opencontent-flink-operator-catalog@sha256:9f673bd4ab11a5734cdf79bf18c7c5bcb52ded1c7faf9e24e3355f3f6e4edb97
+    icr.io/cpopen/ibm-opencontent-flink-operator-catalog@sha256:d3970f055e5bfbe77cd4fbfa9da86bb39597b9474c19fd0a3190cb568c7534af
   priority: 100
   grpcPodConfig:
     securityContextConfig: restricted

--- a/descriptors/op-olm/catalog_source.yaml
+++ b/descriptors/op-olm/catalog_source.yaml
@@ -22,7 +22,7 @@ spec:
   grpcPodConfig:
     securityContextConfig: restricted
 ---
-# IBM CS Flink Operator Catalog 1.20.2 (2.0.18)
+# IBM CS Flink Operator Catalog 1.20.2 (2.0.19)
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -33,7 +33,7 @@ spec:
   publisher: IBM
   sourceType: grpc
   image: >-
-    icr.io/cpopen/ibm-opencontent-flink-operator-catalog@sha256:d68536ac84dafca1a2041bb5511f487aaf52e239b1be340e79801e5c419e9f44
+    icr.io/cpopen/ibm-opencontent-flink-operator-catalog@sha256:9f673bd4ab11a5734cdf79bf18c7c5bcb52ded1c7faf9e24e3355f3f6e4edb97
   priority: 100
   grpcPodConfig:
     securityContextConfig: restricted

--- a/descriptors/patterns/ibm_cp4a_cr_production_FC_bai.yaml
+++ b/descriptors/patterns/ibm_cp4a_cr_production_FC_bai.yaml
@@ -386,7 +386,8 @@ spec:
 
     flink:
       # Use this parameter only for CNCF platform.
-      run_as_user_cncf: 1001
+      # Only update this parameter value to use "1001" when upgrading from 25.0.0-IF004 or later otherwise leave as default "1000"
+      run_as_user_cncf: 1000
       
       # Use this parameter to set the number of flink job manager pod replicas. The default value is 1.
       # If set to a value greater than 1, Flink HA (high-availability) will be enabled.

--- a/descriptors/patterns/ibm_cp4a_cr_production_bai.yaml
+++ b/descriptors/patterns/ibm_cp4a_cr_production_bai.yaml
@@ -211,10 +211,6 @@ spec:
     # Image pull policy for BAI images.
     # If not set, shared_configuration.images.pull_policy is used.
     image_pull_policy: "IfNotPresent"
-    
-    flink:
-      # Use this parameter only for CNCF platform.
-      run_as_user_cncf: 1001
       
     # The Flink job for processing BPMN events.
     bpmn:

--- a/descriptors/patterns/ibm_cp4a_cr_production_bai.yaml
+++ b/descriptors/patterns/ibm_cp4a_cr_production_bai.yaml
@@ -211,6 +211,10 @@ spec:
     # Image pull policy for BAI images.
     # If not set, shared_configuration.images.pull_policy is used.
     image_pull_policy: "IfNotPresent"
+
+    flink:
+      # Use this parameter only for CNCF platform when upgrade from 25.0.0 IF004 to 25.0.0 IF005
+      run_as_user_cncf: 1000
       
     # The Flink job for processing BPMN events.
     bpmn:

--- a/scripts/airgap/bai-case-to-be-mirrored-25.0.0-IF005.txt
+++ b/scripts/airgap/bai-case-to-be-mirrored-25.0.0-IF005.txt
@@ -40,7 +40,7 @@ cases:
     ocMirror:
       disableMerge: true
 - name: ibm-cs-flink
-  version: 2.0.18
+  version: 2.0.19
   catalogGeneration:
     ocMirror:
       disableMerge: true


### PR DESCRIPTION
Reverts icp4a/cert-kubernetes-bai#4
Flink 2.0.19 is now published. So, reverting this PR.